### PR TITLE
chore: update firmware and custom wake-word models

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.7.2
+      esphome-version: 2025.9.0
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.6.2
+      esphome-version: 2025.7.2
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.5.1
+      esphome-version: 2025.6.2
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
 
   comment:
-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'esphome/home-assistant-voice-pe'
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner == 'esphome'
     name: Comment on PR
     runs-on: ubuntu-latest
     needs:
@@ -78,7 +78,7 @@ jobs:
         run: |-
           echo "## Firmware built successfully!" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "[Install here](https://esphome.github.io/home-assistant-voice-pe/?version=${{ github.event.release.tag_name }}) and test **before** approving deployment to beta or production." >> $GITHUB_STEP_SUMMARY
+          echo "[Install here](https://esphome.github.io/${{ github.event.repository.name }}/?version=${{ github.event.release.tag_name }}) and test **before** approving deployment to beta or production." >> $GITHUB_STEP_SUMMARY
 
   upload-to-release:
     name: Upload to Release
@@ -97,7 +97,7 @@ jobs:
       - upload-to-r2
     with:
       version: ${{ github.event.release.tag_name }}
-      directory: home-assistant-voice-pe
+      directory: ${{ github.event.repository.name }}
       channel: beta
       manifest-filename: manifest-beta.json
     secrets: inherit
@@ -110,7 +110,7 @@ jobs:
       - upload-to-r2
     with:
       version: ${{ github.event.release.tag_name }}
-      directory: home-assistant-voice-pe
+      directory: ${{ github.event.repository.name }}
       channel: production
       manifest-filename: manifest.json
     secrets: inherit

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
       - build-firmware
     steps:
       - name: Comment on PR
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@v8.0.0
         with:
           script: |-
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       files: |
         home-assistant-voice.factory.yaml
         home-assistant-voice.8mb.yaml
-      esphome-version: 2025.9.0
+      esphome-version: 2025.9.3
       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build-firmware:
     name: Build Firmware
-    uses: esphome/workflows/.github/workflows/build.yml@2025.4.0
+    uses: esphome/workflows/.github/workflows/build.yml@2025.8.1
     with:
       files: |
         home-assistant-voice.factory.yaml
@@ -62,7 +62,7 @@ jobs:
     name: Upload to R2
     needs:
       - build-firmware
-    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@2025.4.0
+    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@2025.8.1
     with:
       directory: home-assistant-voice-pe
     secrets: inherit
@@ -83,7 +83,7 @@ jobs:
   upload-to-release:
     name: Upload to Release
     if: github.event_name == 'release'
-    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.4.0
+    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.8.1
     needs:
       - build-firmware
     with:
@@ -92,7 +92,7 @@ jobs:
   promote-beta:
     name: Promote to Beta
     if: github.event_name == 'release'
-    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.4.0
+    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.8.1
     needs:
       - upload-to-r2
     with:
@@ -105,7 +105,7 @@ jobs:
   promote-prod:
     name: Promote to Production
     if: github.event_name == 'release' && github.event.release.prerelease == false
-    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.4.0
+    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.8.1
     needs:
       - upload-to-r2
     with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -90,7 +90,7 @@ jobs:
             file.write(html_content)
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3.0.1
+        uses: actions/upload-pages-artifact@v4.0.0
         with:
           path: static
           retention-days: 1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v5.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
 

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
 
       - name: Set up Python
         uses: actions/setup-python@v5

--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -14,6 +14,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⤵️ Check out configuration from GitHub
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v5.0.0
       - name: 🚀 Run yamllint
         run: yamllint --strict .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- Root YAML configs: `home-assistant-voice.yaml` (main), `home-assistant-voice.factory.yaml`, `home-assistant-voice.8mb.yaml`, `voice-kit.yaml`.
+- Custom ESPHome component: `esphome/components/voice_kit/` (C++: `voice_kit.{h,cpp}`, Python codegen: `__init__.py`).
+- Modules and includes: `modules/*.yaml` (e.g., `grove-i2c.yaml`, `grove-power.yaml`).
+- Assets: `sounds/` and `static/`. CI workflows: `.github/workflows/`.
+
+## Build, Test, and Development Commands
+- Validate config: `esphome config home-assistant-voice.yaml` — schema and deps check.
+- Compile firmware: `esphome compile home-assistant-voice.yaml`.
+- Flash/run (USB/Web): `esphome run home-assistant-voice.yaml`.
+- Docker alternative: `docker run --rm -v "$PWD":/config ghcr.io/esphome/esphome compile home-assistant-voice.yaml`.
+- YAML lint: `yamllint --strict .` (uses `.yamllint`).
+- Format C++: `clang-format -i esphome/components/voice_kit/*.{h,cpp}` (style in `.clang-format`).
+
+## Coding Style & Naming Conventions
+- YAML: 2-space indent, one blank line max between blocks; IDs and substitutions use `snake_case` (e.g., `voice_assistant_phase`).
+- C++: follow `.clang-format`; member variables use trailing `_` (e.g., `firmware_bin_`), functions `lower_snake_case`, constants `UPPER_SNAKE_CASE`.
+- Python (codegen): prefer Black-compatible style; keep minimal logic and validate via `esphome` build.
+- File names: hyphenated for top-level YAML, `snake_case` for module YAML.
+
+## Testing Guidelines
+- No unit tests; use compile/flash cycle and device logs for verification.
+- Before PRs: run `esphome config`, `esphome compile`, and `yamllint --strict .`.
+- Add small, reviewable YAML modules under `modules/` when isolating changes.
+
+## Commit & Pull Request Guidelines
+- Commits: imperative mood, concise summary; reference PR/issue when applicable (e.g., “Enable IPv6 support (#394)”).
+- PRs must include: purpose, summary of changes, test steps (commands + expected device behavior), and any UI/LED/audio changes.
+- Keep PRs focused; update `README.md` or comments when behavior changes.
+
+## Security & Configuration Tips
+- Do not commit secrets (Wi‑Fi SSIDs/passwords). Prefer installer flows or `substitutions` with safe defaults.
+- Avoid logging sensitive data; keep `logger:` levels appropriate.
+- Verify firmware URLs and checksums when touching `voice_kit` DFU settings in `__init__.py`.
+

--- a/README.md
+++ b/README.md
@@ -5,3 +5,23 @@ This is the ESPHome source code of the [Home Assistant Voice: Preview Edition](h
 See [the documentation](https://voice-pe.home-assistant.io/) for set up and troubleshooting.
 
 If you need to re-install the firmware, [use this installer](https://esphome.github.io/home-assistant-voice-pe/).
+
+## Fork Information
+
+This repository is a fork of the upstream project:
+
+- Upstream: https://github.com/esphome/home-assistant-voice-pe
+- This fork: https://github.com/Jayson-Stangel/home-assistant-voice-te
+
+Purpose: maintain local tweaks (e.g., custom micro_wake_word models) and experiments while tracking upstream closely. Please open core issues upstream unless specific to this fork.
+
+### Keeping the fork in sync
+
+```
+git fetch upstream
+git checkout dev
+git rebase upstream/dev
+git push origin dev --force-with-lease
+```
+
+CI in this fork mirrors upstream and builds from `dev`.

--- a/diffs/shortstat_upstream_8178e25_to_8083b3e3dbc06804a54bc1b7192ab7a59a481c23.txt
+++ b/diffs/shortstat_upstream_8178e25_to_8083b3e3dbc06804a54bc1b7192ab7a59a481c23.txt
@@ -1,0 +1,1 @@
+ 4 files changed, 101 insertions(+), 44 deletions(-)

--- a/diffs/shortstat_upstream_dev_to_chores-update-firmware-tts.txt
+++ b/diffs/shortstat_upstream_dev_to_chores-update-firmware-tts.txt
@@ -1,0 +1,1 @@
+ 3 files changed, 59 insertions(+), 4 deletions(-)

--- a/diffs/summary_upstream_8178e25_to_8083b3e3dbc06804a54bc1b7192ab7a59a481c23.txt
+++ b/diffs/summary_upstream_8178e25_to_8083b3e3dbc06804a54bc1b7192ab7a59a481c23.txt
@@ -1,0 +1,4 @@
+M	.github/workflows/build.yml
+M	.github/workflows/gh-pages.yml
+M	.github/workflows/yaml-lint.yml
+M	home-assistant-voice.yaml

--- a/diffs/summary_upstream_dev_to_chores-update-firmware-tts.txt
+++ b/diffs/summary_upstream_dev_to_chores-update-firmware-tts.txt
@@ -1,0 +1,3 @@
+A	AGENTS.md
+M	README.md
+M	home-assistant-voice.yaml

--- a/diffs/upstream_8178e25_to_8083b3e3dbc06804a54bc1b7192ab7a59a481c23.patch
+++ b/diffs/upstream_8178e25_to_8083b3e3dbc06804a54bc1b7192ab7a59a481c23.patch
@@ -1,0 +1,420 @@
+diff --git a/.github/workflows/build.yml b/.github/workflows/build.yml
+index 616769a..d7aed0d 100644
+--- a/.github/workflows/build.yml
++++ b/.github/workflows/build.yml
+@@ -16,25 +16,25 @@ concurrency:
+ jobs:
+   build-firmware:
+     name: Build Firmware
+-    uses: esphome/workflows/.github/workflows/build.yml@2025.4.0
++    uses: esphome/workflows/.github/workflows/build.yml@2025.8.1
+     with:
+       files: |
+         home-assistant-voice.factory.yaml
+         home-assistant-voice.8mb.yaml
+-      esphome-version: 2025.5.1
++      esphome-version: 2025.9.3
+       release-summary: ${{ github.event_name == 'release' && github.event.release.body || '' }}
+       release-url: ${{ github.event_name == 'release' && github.event.release.html_url || '' }}
+       release-version: ${{ github.event_name == 'release' && github.event.release.tag_name || '' }}
+ 
+   comment:
+-    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == 'esphome/home-assistant-voice-pe'
++    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.owner == 'esphome'
+     name: Comment on PR
+     runs-on: ubuntu-latest
+     needs:
+       - build-firmware
+     steps:
+       - name: Comment on PR
+-        uses: actions/github-script@v7.0.1
++        uses: actions/github-script@v8.0.0
+         with:
+           script: |-
+             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+@@ -62,7 +62,7 @@ jobs:
+     name: Upload to R2
+     needs:
+       - build-firmware
+-    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@2025.4.0
++    uses: esphome/workflows/.github/workflows/upload-to-r2.yml@2025.8.1
+     with:
+       directory: home-assistant-voice-pe
+     secrets: inherit
+@@ -78,12 +78,12 @@ jobs:
+         run: |-
+           echo "## Firmware built successfully!" >> $GITHUB_STEP_SUMMARY
+           echo "" >> $GITHUB_STEP_SUMMARY
+-          echo "[Install here](https://esphome.github.io/home-assistant-voice-pe/?version=${{ github.event.release.tag_name }}) and test **before** approving deployment to beta or production." >> $GITHUB_STEP_SUMMARY
++          echo "[Install here](https://esphome.github.io/${{ github.event.repository.name }}/?version=${{ github.event.release.tag_name }}) and test **before** approving deployment to beta or production." >> $GITHUB_STEP_SUMMARY
+ 
+   upload-to-release:
+     name: Upload to Release
+     if: github.event_name == 'release'
+-    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.4.0
++    uses: esphome/workflows/.github/workflows/upload-to-gh-release.yml@2025.8.1
+     needs:
+       - build-firmware
+     with:
+@@ -92,12 +92,12 @@ jobs:
+   promote-beta:
+     name: Promote to Beta
+     if: github.event_name == 'release'
+-    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.4.0
++    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.8.1
+     needs:
+       - upload-to-r2
+     with:
+       version: ${{ github.event.release.tag_name }}
+-      directory: home-assistant-voice-pe
++      directory: ${{ github.event.repository.name }}
+       channel: beta
+       manifest-filename: manifest-beta.json
+     secrets: inherit
+@@ -105,12 +105,12 @@ jobs:
+   promote-prod:
+     name: Promote to Production
+     if: github.event_name == 'release' && github.event.release.prerelease == false
+-    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.4.0
++    uses: esphome/workflows/.github/workflows/promote-r2.yml@2025.8.1
+     needs:
+       - upload-to-r2
+     with:
+       version: ${{ github.event.release.tag_name }}
+-      directory: home-assistant-voice-pe
++      directory: ${{ github.event.repository.name }}
+       channel: production
+       manifest-filename: manifest.json
+     secrets: inherit
+diff --git a/.github/workflows/gh-pages.yml b/.github/workflows/gh-pages.yml
+index 743e60d..0b861f8 100644
+--- a/.github/workflows/gh-pages.yml
++++ b/.github/workflows/gh-pages.yml
+@@ -27,10 +27,10 @@ jobs:
+     runs-on: ubuntu-latest
+     steps:
+       - name: Checkout
+-        uses: actions/checkout@v4.2.2
++        uses: actions/checkout@v5.0.0
+ 
+       - name: Set up Python
+-        uses: actions/setup-python@v5
++        uses: actions/setup-python@v6
+         with:
+           python-version: "3.13"
+ 
+@@ -90,7 +90,7 @@ jobs:
+             file.write(html_content)
+ 
+       - name: Upload artifact
+-        uses: actions/upload-pages-artifact@v3.0.1
++        uses: actions/upload-pages-artifact@v4.0.0
+         with:
+           path: static
+           retention-days: 1
+diff --git a/.github/workflows/yaml-lint.yml b/.github/workflows/yaml-lint.yml
+index 6bcd132..5b7cc97 100644
+--- a/.github/workflows/yaml-lint.yml
++++ b/.github/workflows/yaml-lint.yml
+@@ -14,6 +14,6 @@ jobs:
+     runs-on: ubuntu-latest
+     steps:
+       - name: ⤵️ Check out configuration from GitHub
+-        uses: actions/checkout@v4.2.2
++        uses: actions/checkout@v5.0.0
+       - name: 🚀 Run yamllint
+         run: yamllint --strict .
+diff --git a/home-assistant-voice.yaml b/home-assistant-voice.yaml
+index 05aeb11..ad20e49 100644
+--- a/home-assistant-voice.yaml
++++ b/home-assistant-voice.yaml
+@@ -16,12 +16,23 @@ substitutions:
+   voice_assist_error_phase_id: '11'
+   # Change this to true in case you ahve a hidden SSID at home.
+   hidden_ssid: "false"
++  # Substitutions for audio files
++  jack_connected_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/jack_connected.flac
++  jack_disconnected_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/jack_disconnected.flac
++  mute_switch_on_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/mute_switch_on.flac
++  mute_switch_off_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/mute_switch_off.flac
++  timer_finished_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/timer_finished.flac
++  wake_word_triggered_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/wake_word_triggered.flac
++  center_button_press_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_press.flac
++  center_button_double_press_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_double_press.flac
++  center_button_triple_press_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_triple_press.flac
++  center_button_long_press_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_long_press.flac
+ 
+ esphome:
+   name: home-assistant-voice
+   friendly_name: Home Assistant Voice
+   name_add_mac_suffix: true
+-  min_version: 2025.5.1
++  min_version: 2025.9.3
+   on_boot:
+     priority: 375
+     then:
+@@ -86,6 +97,7 @@ api:
+     - script.execute: control_leds
+   on_client_disconnected:
+     - script.execute: control_leds
++  encryption:   # Uses key set by Home Assistant
+ 
+ ota:
+   - platform: esphome
+@@ -555,7 +567,7 @@ light:
+             auto light_color = id(led_ring).current_values;
+             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
+                   light_color.get_blue() * 255);
+-            for (int i = 0; i < 12; i++) {
++            for (uint8_t i = 0; i < 12; i++) {
+               if (i == id(global_led_animation_index) % 12) {
+                 it[i] = color;
+               } else if (i == (id(global_led_animation_index) + 11) % 12) {
+@@ -580,7 +592,7 @@ light:
+             auto light_color = id(led_ring).current_values;
+             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
+                   light_color.get_blue() * 255);
+-            for (int i = 0; i < 12; i++) {
++            for (uint8_t i = 0; i < 12; i++) {
+               if (i == id(global_led_animation_index) % 12) {
+                 it[i] = color;
+               } else if (i == (id(global_led_animation_index) + 11) % 12) {
+@@ -612,7 +624,7 @@ light:
+             auto light_color = id(led_ring).current_values;
+             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
+                   light_color.get_blue() * 255);
+-            for (int i = 0; i < 12; i++) {
++            for (uint8_t i = 0; i < 12; i++) {
+               if (i == id(global_led_animation_index) % 12) {
+                 it[i] = color * uint8_t(255/brightness_step_number*(brightness_step_number-brightness_step));
+               } else if (i == (id(global_led_animation_index) + 6) % 12) {
+@@ -637,7 +649,7 @@ light:
+             auto light_color = id(led_ring).current_values;
+             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
+                   light_color.get_blue() * 255);
+-            for (int i = 0; i < 12; i++) {
++            for (uint8_t i = 0; i < 12; i++) {
+               if (i == (id(global_led_animation_index)) % 12) {
+                 it[i] = color;
+               } else if (i == ( id(global_led_animation_index) + 1) % 12) {
+@@ -663,7 +675,7 @@ light:
+             auto light_color = id(led_ring).current_values;
+             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
+                   light_color.get_blue() * 255);
+-            for (int i = 0; i < 12; i++) {
++            for (uint8_t i = 0; i < 12; i++) {
+               if ( light_color.get_state() ) {
+                 it[i] = color;
+               } else {
+@@ -683,6 +695,19 @@ light:
+               it[6] = muted_color;
+               it[7] = Color::BLACK;
+             }
++      - addressable_lambda:
++          name: "Voice kit startup failed"
++          # update_interval: 16ms
++          lambda: |-
++            static int8_t index = 0;
++            Color fail_color(255, 0, 0);
++            for (uint8_t i = 0; i < 12; i++) {
++              if (i % 3) {
++                it[i] = Color::BLACK;
++              } else {
++                it[i] = fail_color;
++              }
++            }
+       - addressable_lambda:
+           name: "Volume Display"
+           update_interval: 50ms
+@@ -692,7 +717,7 @@ light:
+                   light_color.get_blue() * 255);
+             Color silenced_color(255, 0, 0);
+             auto volume_ratio = 12.0f * id(external_media_player).volume;
+-            for (int i = 0; i < 12; i++) {
++            for (uint8_t i = 0; i < 12; i++) {
+               if (i <= volume_ratio) {
+                 it[(6+i)%12] = color * min( 255.0f * (volume_ratio - i) , 255.0f ) ;
+               } else {
+@@ -718,7 +743,7 @@ light:
+             auto light_color = id(voice_assistant_leds).current_values;
+             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
+                   light_color.get_blue() * 255);
+-            for (int i = 0; i < 12; i++) {
++            for (uint8_t i = 0; i < 12; i++) {
+               it[i] = color;
+             }
+       - addressable_twinkle:
+@@ -736,7 +761,7 @@ light:
+               brightness_decreasing = true;
+             }
+             Color error_color(255, 0, 0);
+-            for (int i = 0; i < 12; i++) {
++            for (uint8_t i = 0; i < 12; i++) {
+               it[i] = error_color * uint8_t(255/brightness_step_number*(brightness_step_number-brightness_step));
+             }
+             if (brightness_decreasing) {
+@@ -762,7 +787,7 @@ light:
+             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
+                   light_color.get_blue() * 255);
+             Color muted_color(255, 0, 0);
+-            for (int i = 0; i < 12; i++) {
++            for (uint8_t i = 0; i < 12; i++) {
+               it[i] = color * uint8_t(255/brightness_step_number*(brightness_step_number-brightness_step));
+             }
+             if ( id(master_mute_switch).state ) {
+@@ -787,7 +812,7 @@ light:
+             Color muted_color(255, 0, 0);
+             auto timer_ratio = 12.0f * id(first_active_timer).seconds_left / max(id(first_active_timer).total_seconds , static_cast<uint32_t>(1));
+             uint8_t last_led_on = static_cast<uint8_t>(ceil(timer_ratio)) - 1;
+-            for (int i = 0; i < 12; i++) {
++            for (uint8_t i = 0; i < 12; i++) {
+               float brightness_dip = ( i == id(global_led_animation_index) % 12 && i != last_led_on ) ? 0.9f : 1.0f ;
+               if (i <= timer_ratio) {
+                 it[i] = color * min(255.0f * brightness_dip * (timer_ratio - i) , 255.0f * brightness_dip) ;
+@@ -816,7 +841,7 @@ light:
+             if (initial_run) {
+               index = 0;
+             }
+-            for (int i = 0; i < 12; i++) {
++            for (uint8_t i = 0; i < 12; i++) {
+               if (i <= index ) {
+                 it[i] = Color::BLACK;
+               } else {
+@@ -833,7 +858,7 @@ light:
+             if (initial_run) {
+               index = 0;
+             }
+-            for (int i = 0; i < 12; i++) {
++            for (uint8_t i = 0; i < 12; i++) {
+               if (i <= index ) {
+                 it[i] = color;
+               } else {
+@@ -853,7 +878,7 @@ light:
+               Color color(light_color.get_red() * 255, light_color.get_green() * 255,
+                     light_color.get_blue() * 255);
+               if (index <= 6) {
+-                for (int i = 0; i < 12; i++) {
++                for (uint8_t i = 0; i < 12; i++) {
+                   if (i == index) {
+                     it[i] = color;
+                   } else if (i == (12 - index) % 12) {
+@@ -876,7 +901,7 @@ light:
+               Color color(light_color.get_red() * 255, light_color.get_green() * 255,
+                     light_color.get_blue() * 255);
+               if (index <= 6) {
+-                for (int i = 0; i < 12; i++) {
++                for (uint8_t i = 0; i < 12; i++) {
+                   if (i == 6 - index) {
+                     it[i] = color;
+                   } else if (i == (6 + index) % 12) {
+@@ -970,6 +995,10 @@ script:
+   - id: control_leds
+     then:
+       - lambda: |
++          if (id(voice_kit_component).is_failed()) {
++            id(control_leds_voice_kit_startup_failed).execute();
++            return;
++          }
+           id(check_if_timers_active).execute();
+           if (id(is_timer_active)){
+             id(fetch_first_active_timer).execute();
+@@ -1012,6 +1041,18 @@ script:
+             id(control_leds_voice_assistant_idle_phase).execute();
+           }
+ 
++  # Script executed if voice_kit startup failed
++  # Static red "X"
++  - id: control_leds_voice_kit_startup_failed
++    then:
++      - light.turn_on:
++          brightness: 40%
++          red: 0%
++          green: 0%
++          blue: 0%
++          id: voice_assistant_leds
++          effect: "Voice kit startup failed"
++
+   # Script executed during Improv BLE
+   # Warm White Twinkle
+   - id: control_leds_improv_ble_state
+@@ -1486,13 +1527,13 @@ media_player:
+               duration: 1.0s
+     files:
+       - id: center_button_press_sound
+-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_press.flac
++        file: ${center_button_press_sound_file}
+       - id: center_button_double_press_sound
+-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_double_press.flac
++        file: ${center_button_double_press_sound_file}
+       - id: center_button_triple_press_sound
+-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_triple_press.flac
++        file: ${center_button_triple_press_sound_file}
+       - id: center_button_long_press_sound
+-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_long_press.flac
++        file: ${center_button_long_press_sound_file}
+       - id: factory_reset_initiated_sound
+         file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/factory_reset_initiated.mp3
+       - id: factory_reset_cancelled_sound
+@@ -1500,17 +1541,17 @@ media_player:
+       - id: factory_reset_confirmed_sound
+         file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/factory_reset_confirmed.mp3
+       - id: jack_connected_sound
+-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/jack_connected.flac
++        file: ${jack_connected_sound_file}
+       - id: jack_disconnected_sound
+-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/jack_disconnected.flac
++        file: ${jack_disconnected_sound_file}
+       - id: mute_switch_on_sound
+-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/mute_switch_on.flac
++        file: ${mute_switch_on_sound_file}
+       - id: mute_switch_off_sound
+-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/mute_switch_off.flac
++        file: ${mute_switch_off_sound_file}
+       - id: timer_finished_sound
+-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/timer_finished.flac
++        file: ${timer_finished_sound_file}
+       - id: wake_word_triggered_sound
+-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/wake_word_triggered.flac
++        file: ${wake_word_triggered_sound_file}
+       - id: easter_egg_tick_sound
+         file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/easter_egg_tick.mp3
+       - id: easter_egg_tada_sound
+@@ -1519,6 +1560,7 @@ media_player:
+         file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/error_cloud_expired.mp3
+ 
+ voice_kit:
++  id: voice_kit_component
+   i2c_id: internal_i2c
+   reset_pin: GPIO4
+   firmware:
+@@ -1686,11 +1728,26 @@ voice_assistant:
+   on_stt_vad_end:
+     - lambda: id(voice_assistant_phase) = ${voice_assist_thinking_phase_id};
+     - script.execute: control_leds
++  on_intent_progress:
++    - if:
++        condition:
++          # A nonempty x variable means a streaming TTS url was sent to the media player
++          lambda: 'return !x.empty();'
++        then:
++          - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
++          - script.execute: control_leds
++          # Start a script that would potentially enable the stop word if the response is longer than a second
++          - script.execute: activate_stop_word_once
+   on_tts_start:
+-    - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
+-    - script.execute: control_leds
+-    # Start a script that would potentially enable the stop word if the response is longer than a second
+-    - script.execute: activate_stop_word_once
++    - if:
++        condition:
++          # The intent_progress trigger didn't start the TTS Reponse
++          lambda: 'return id(voice_assistant_phase) != ${voice_assist_replying_phase_id};'
++        then:
++          - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
++          - script.execute: control_leds
++          # Start a script that would potentially enable the stop word if the response is longer than a second
++          - script.execute: activate_stop_word_once
+   # When the voice assistant ends ...
+   on_end:
+     - wait_until:

--- a/diffs/upstream_dev_to_chores-update-firmware-tts.patch
+++ b/diffs/upstream_dev_to_chores-update-firmware-tts.patch
@@ -1,0 +1,88 @@
+diff --git a/AGENTS.md b/AGENTS.md
+new file mode 100644
+index 0000000..cf2b7c9
+--- /dev/null
++++ b/AGENTS.md
+@@ -0,0 +1,37 @@
++# Repository Guidelines
++
++## Project Structure & Module Organization
++- Root YAML configs: `home-assistant-voice.yaml` (main), `home-assistant-voice.factory.yaml`, `home-assistant-voice.8mb.yaml`, `voice-kit.yaml`.
++- Custom ESPHome component: `esphome/components/voice_kit/` (C++: `voice_kit.{h,cpp}`, Python codegen: `__init__.py`).
++- Modules and includes: `modules/*.yaml` (e.g., `grove-i2c.yaml`, `grove-power.yaml`).
++- Assets: `sounds/` and `static/`. CI workflows: `.github/workflows/`.
++
++## Build, Test, and Development Commands
++- Validate config: `esphome config home-assistant-voice.yaml` — schema and deps check.
++- Compile firmware: `esphome compile home-assistant-voice.yaml`.
++- Flash/run (USB/Web): `esphome run home-assistant-voice.yaml`.
++- Docker alternative: `docker run --rm -v "$PWD":/config ghcr.io/esphome/esphome compile home-assistant-voice.yaml`.
++- YAML lint: `yamllint --strict .` (uses `.yamllint`).
++- Format C++: `clang-format -i esphome/components/voice_kit/*.{h,cpp}` (style in `.clang-format`).
++
++## Coding Style & Naming Conventions
++- YAML: 2-space indent, one blank line max between blocks; IDs and substitutions use `snake_case` (e.g., `voice_assistant_phase`).
++- C++: follow `.clang-format`; member variables use trailing `_` (e.g., `firmware_bin_`), functions `lower_snake_case`, constants `UPPER_SNAKE_CASE`.
++- Python (codegen): prefer Black-compatible style; keep minimal logic and validate via `esphome` build.
++- File names: hyphenated for top-level YAML, `snake_case` for module YAML.
++
++## Testing Guidelines
++- No unit tests; use compile/flash cycle and device logs for verification.
++- Before PRs: run `esphome config`, `esphome compile`, and `yamllint --strict .`.
++- Add small, reviewable YAML modules under `modules/` when isolating changes.
++
++## Commit & Pull Request Guidelines
++- Commits: imperative mood, concise summary; reference PR/issue when applicable (e.g., “Enable IPv6 support (#394)”).
++- PRs must include: purpose, summary of changes, test steps (commands + expected device behavior), and any UI/LED/audio changes.
++- Keep PRs focused; update `README.md` or comments when behavior changes.
++
++## Security & Configuration Tips
++- Do not commit secrets (Wi‑Fi SSIDs/passwords). Prefer installer flows or `substitutions` with safe defaults.
++- Avoid logging sensitive data; keep `logger:` levels appropriate.
++- Verify firmware URLs and checksums when touching `voice_kit` DFU settings in `__init__.py`.
++
+diff --git a/README.md b/README.md
+index c06bd6a..867fc8d 100644
+--- a/README.md
++++ b/README.md
+@@ -5,3 +5,23 @@ This is the ESPHome source code of the [Home Assistant Voice: Preview Edition](h
+ See [the documentation](https://voice-pe.home-assistant.io/) for set up and troubleshooting.
+ 
+ If you need to re-install the firmware, [use this installer](https://esphome.github.io/home-assistant-voice-pe/).
++
++## Fork Information
++
++This repository is a fork of the upstream project:
++
++- Upstream: https://github.com/esphome/home-assistant-voice-pe
++- This fork: https://github.com/Jayson-Stangel/home-assistant-voice-te
++
++Purpose: maintain local tweaks (e.g., custom micro_wake_word models) and experiments while tracking upstream closely. Please open core issues upstream unless specific to this fork.
++
++### Keeping the fork in sync
++
++```
++git fetch upstream
++git checkout dev
++git rebase upstream/dev
++git push origin dev --force-with-lease
++```
++
++CI in this fork mirrors upstream and builds from `dev`.
+diff --git a/home-assistant-voice.yaml b/home-assistant-voice.yaml
+index ad20e49..469f387 100644
+--- a/home-assistant-voice.yaml
++++ b/home-assistant-voice.yaml
+@@ -1592,10 +1592,8 @@ micro_wake_word:
+   models:
+     - model: https://github.com/kahrendt/microWakeWord/releases/download/okay_nabu_20241226.3/okay_nabu.json
+       id: okay_nabu
+-    - model: hey_jarvis
+-      id: hey_jarvis
+-    - model: hey_mycroft
+-      id: hey_mycroft
++    - model: github://Jayson-Stangel/microWakeWord_models/tinkerbell/v0/model_output/tinkerbell.json
++      id: tinkerbell
+     - model: https://github.com/kahrendt/microWakeWord/releases/download/stop/stop.json
+       id: stop
+       internal: true

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -555,7 +555,7 @@ light:
             auto light_color = id(led_ring).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
-            for (int i = 0; i < 12; i++) {
+            for (uint8_t i = 0; i < 12; i++) {
               if (i == id(global_led_animation_index) % 12) {
                 it[i] = color;
               } else if (i == (id(global_led_animation_index) + 11) % 12) {
@@ -580,7 +580,7 @@ light:
             auto light_color = id(led_ring).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
-            for (int i = 0; i < 12; i++) {
+            for (uint8_t i = 0; i < 12; i++) {
               if (i == id(global_led_animation_index) % 12) {
                 it[i] = color;
               } else if (i == (id(global_led_animation_index) + 11) % 12) {
@@ -612,7 +612,7 @@ light:
             auto light_color = id(led_ring).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
-            for (int i = 0; i < 12; i++) {
+            for (uint8_t i = 0; i < 12; i++) {
               if (i == id(global_led_animation_index) % 12) {
                 it[i] = color * uint8_t(255/brightness_step_number*(brightness_step_number-brightness_step));
               } else if (i == (id(global_led_animation_index) + 6) % 12) {
@@ -637,7 +637,7 @@ light:
             auto light_color = id(led_ring).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
-            for (int i = 0; i < 12; i++) {
+            for (uint8_t i = 0; i < 12; i++) {
               if (i == (id(global_led_animation_index)) % 12) {
                 it[i] = color;
               } else if (i == ( id(global_led_animation_index) + 1) % 12) {
@@ -663,7 +663,7 @@ light:
             auto light_color = id(led_ring).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
-            for (int i = 0; i < 12; i++) {
+            for (uint8_t i = 0; i < 12; i++) {
               if ( light_color.get_state() ) {
                 it[i] = color;
               } else {
@@ -684,6 +684,19 @@ light:
               it[7] = Color::BLACK;
             }
       - addressable_lambda:
+          name: "Voice kit startup failed"
+          # update_interval: 16ms
+          lambda: |-
+            static int8_t index = 0;
+            Color fail_color(255, 0, 0);
+            for (uint8_t i = 0; i < 12; i++) {
+              if (i % 3) {
+                it[i] = Color::BLACK;
+              } else {
+                it[i] = fail_color;
+              }
+            }
+      - addressable_lambda:
           name: "Volume Display"
           update_interval: 50ms
           lambda: |-
@@ -692,7 +705,7 @@ light:
                   light_color.get_blue() * 255);
             Color silenced_color(255, 0, 0);
             auto volume_ratio = 12.0f * id(external_media_player).volume;
-            for (int i = 0; i < 12; i++) {
+            for (uint8_t i = 0; i < 12; i++) {
               if (i <= volume_ratio) {
                 it[(6+i)%12] = color * min( 255.0f * (volume_ratio - i) , 255.0f ) ;
               } else {
@@ -718,7 +731,7 @@ light:
             auto light_color = id(voice_assistant_leds).current_values;
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
-            for (int i = 0; i < 12; i++) {
+            for (uint8_t i = 0; i < 12; i++) {
               it[i] = color;
             }
       - addressable_twinkle:
@@ -736,7 +749,7 @@ light:
               brightness_decreasing = true;
             }
             Color error_color(255, 0, 0);
-            for (int i = 0; i < 12; i++) {
+            for (uint8_t i = 0; i < 12; i++) {
               it[i] = error_color * uint8_t(255/brightness_step_number*(brightness_step_number-brightness_step));
             }
             if (brightness_decreasing) {
@@ -762,7 +775,7 @@ light:
             Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                   light_color.get_blue() * 255);
             Color muted_color(255, 0, 0);
-            for (int i = 0; i < 12; i++) {
+            for (uint8_t i = 0; i < 12; i++) {
               it[i] = color * uint8_t(255/brightness_step_number*(brightness_step_number-brightness_step));
             }
             if ( id(master_mute_switch).state ) {
@@ -787,7 +800,7 @@ light:
             Color muted_color(255, 0, 0);
             auto timer_ratio = 12.0f * id(first_active_timer).seconds_left / max(id(first_active_timer).total_seconds , static_cast<uint32_t>(1));
             uint8_t last_led_on = static_cast<uint8_t>(ceil(timer_ratio)) - 1;
-            for (int i = 0; i < 12; i++) {
+            for (uint8_t i = 0; i < 12; i++) {
               float brightness_dip = ( i == id(global_led_animation_index) % 12 && i != last_led_on ) ? 0.9f : 1.0f ;
               if (i <= timer_ratio) {
                 it[i] = color * min(255.0f * brightness_dip * (timer_ratio - i) , 255.0f * brightness_dip) ;
@@ -816,7 +829,7 @@ light:
             if (initial_run) {
               index = 0;
             }
-            for (int i = 0; i < 12; i++) {
+            for (uint8_t i = 0; i < 12; i++) {
               if (i <= index ) {
                 it[i] = Color::BLACK;
               } else {
@@ -833,7 +846,7 @@ light:
             if (initial_run) {
               index = 0;
             }
-            for (int i = 0; i < 12; i++) {
+            for (uint8_t i = 0; i < 12; i++) {
               if (i <= index ) {
                 it[i] = color;
               } else {
@@ -853,7 +866,7 @@ light:
               Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                     light_color.get_blue() * 255);
               if (index <= 6) {
-                for (int i = 0; i < 12; i++) {
+                for (uint8_t i = 0; i < 12; i++) {
                   if (i == index) {
                     it[i] = color;
                   } else if (i == (12 - index) % 12) {
@@ -876,7 +889,7 @@ light:
               Color color(light_color.get_red() * 255, light_color.get_green() * 255,
                     light_color.get_blue() * 255);
               if (index <= 6) {
-                for (int i = 0; i < 12; i++) {
+                for (uint8_t i = 0; i < 12; i++) {
                   if (i == 6 - index) {
                     it[i] = color;
                   } else if (i == (6 + index) % 12) {
@@ -970,6 +983,10 @@ script:
   - id: control_leds
     then:
       - lambda: |
+          if (id(voice_kit_component).is_failed()) {
+            id(control_leds_voice_kit_startup_failed).execute();
+            return;
+          }
           id(check_if_timers_active).execute();
           if (id(is_timer_active)){
             id(fetch_first_active_timer).execute();
@@ -1011,6 +1028,18 @@ script:
           } else if (id(voice_assistant_phase) == ${voice_assist_idle_phase_id}) {
             id(control_leds_voice_assistant_idle_phase).execute();
           }
+
+  # Script executed if voice_kit startup failed
+  # Static red "X"
+  - id: control_leds_voice_kit_startup_failed
+    then:
+      - light.turn_on:
+          brightness: 40%
+          red: 0%
+          green: 0%
+          blue: 0%
+          id: voice_assistant_leds
+          effect: "Voice kit startup failed"
 
   # Script executed during Improv BLE
   # Warm White Twinkle
@@ -1519,6 +1548,7 @@ media_player:
         file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/error_cloud_expired.mp3
 
 voice_kit:
+  id: voice_kit_component
   i2c_id: internal_i2c
   reset_pin: GPIO4
   firmware:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -32,7 +32,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2025.7.2
+  min_version: 2025.9.0
   on_boot:
     priority: 375
     then:
@@ -97,6 +97,7 @@ api:
     - script.execute: control_leds
   on_client_disconnected:
     - script.execute: control_leds
+  encryption:   # Uses key set by Home Assistant
 
 ota:
   - platform: esphome

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1592,10 +1592,8 @@ micro_wake_word:
   models:
     - model: https://github.com/kahrendt/microWakeWord/releases/download/okay_nabu_20241226.3/okay_nabu.json
       id: okay_nabu
-    - model: hey_jarvis
-      id: hey_jarvis
-    - model: hey_mycroft
-      id: hey_mycroft
+    - model: github://Jayson-Stangel/microWakeWord_models/tinkerbell/v0/model_output/tinkerbell.json
+      id: tinkerbell
     - model: https://github.com/kahrendt/microWakeWord/releases/download/stop/stop.json
       id: stop
       internal: true

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -21,7 +21,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2025.5.1
+  min_version: 2025.7.2
   on_boot:
     priority: 375
     then:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1716,11 +1716,26 @@ voice_assistant:
   on_stt_vad_end:
     - lambda: id(voice_assistant_phase) = ${voice_assist_thinking_phase_id};
     - script.execute: control_leds
+  on_intent_progress:
+    - if:
+        condition:
+          # A nonempty x variable means a streaming TTS url was sent to the media player
+          lambda: 'return !x.empty();'
+        then:
+          - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
+          - script.execute: control_leds
+          # Start a script that would potentially enable the stop word if the response is longer than a second
+          - script.execute: activate_stop_word_once
   on_tts_start:
-    - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
-    - script.execute: control_leds
-    # Start a script that would potentially enable the stop word if the response is longer than a second
-    - script.execute: activate_stop_word_once
+    - if:
+        condition:
+          # The intent_progress trigger didn't start the TTS Reponse
+          lambda: 'return id(voice_assistant_phase) != ${voice_assist_replying_phase_id};'
+        then:
+          - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
+          - script.execute: control_leds
+          # Start a script that would potentially enable the stop word if the response is longer than a second
+          - script.execute: activate_stop_word_once
   # When the voice assistant ends ...
   on_end:
     - wait_until:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -16,6 +16,17 @@ substitutions:
   voice_assist_error_phase_id: '11'
   # Change this to true in case you ahve a hidden SSID at home.
   hidden_ssid: "false"
+  # Substitutions for audio files
+  jack_connected_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/jack_connected.flac
+  jack_disconnected_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/jack_disconnected.flac
+  mute_switch_on_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/mute_switch_on.flac
+  mute_switch_off_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/mute_switch_off.flac
+  timer_finished_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/timer_finished.flac
+  wake_word_triggered_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/wake_word_triggered.flac
+  center_button_press_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_press.flac
+  center_button_double_press_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_double_press.flac
+  center_button_triple_press_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_triple_press.flac
+  center_button_long_press_sound_file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_long_press.flac
 
 esphome:
   name: home-assistant-voice
@@ -1515,13 +1526,13 @@ media_player:
               duration: 1.0s
     files:
       - id: center_button_press_sound
-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_press.flac
+        file: ${center_button_press_sound_file}
       - id: center_button_double_press_sound
-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_double_press.flac
+        file: ${center_button_double_press_sound_file}
       - id: center_button_triple_press_sound
-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_triple_press.flac
+        file: ${center_button_triple_press_sound_file}
       - id: center_button_long_press_sound
-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/center_button_long_press.flac
+        file: ${center_button_long_press_sound_file}
       - id: factory_reset_initiated_sound
         file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/factory_reset_initiated.mp3
       - id: factory_reset_cancelled_sound
@@ -1529,17 +1540,17 @@ media_player:
       - id: factory_reset_confirmed_sound
         file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/factory_reset_confirmed.mp3
       - id: jack_connected_sound
-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/jack_connected.flac
+        file: ${jack_connected_sound_file}
       - id: jack_disconnected_sound
-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/jack_disconnected.flac
+        file: ${jack_disconnected_sound_file}
       - id: mute_switch_on_sound
-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/mute_switch_on.flac
+        file: ${mute_switch_on_sound_file}
       - id: mute_switch_off_sound
-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/mute_switch_off.flac
+        file: ${mute_switch_off_sound_file}
       - id: timer_finished_sound
-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/timer_finished.flac
+        file: ${timer_finished_sound_file}
       - id: wake_word_triggered_sound
-        file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/wake_word_triggered.flac
+        file: ${wake_word_triggered_sound_file}
       - id: easter_egg_tick_sound
         file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/easter_egg_tick.mp3
       - id: easter_egg_tada_sound

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -32,7 +32,7 @@ esphome:
   name: home-assistant-voice
   friendly_name: Home Assistant Voice
   name_add_mac_suffix: true
-  min_version: 2025.9.0
+  min_version: 2025.9.3
   on_boot:
     priority: 375
     then:


### PR DESCRIPTION
Summary:
- Sync with upstream esphome/home-assistant-voice-pe@dev (ESPHome 2025.9.3, TTS streaming, dynamic API encryption, workflow updates).
- Preserve custom micro_wake_word models:
  - okay_nabu (unchanged)
  - tinkerbell (github://Jayson-Stangel/microWakeWord_models/…/tinkerbell.json)
  - stop (internal: true)
- Add contributor guide (AGENTS.md) and fork info in README.

Validation:
- yamllint passes clean.
- esphome config valid (requires SSID or temporary wifi.ap: {} for local checks).

Notes:
- CI builds from dev; please merge to dev after review.
- Upstream models hey_jarvis and hey_mycroft intentionally removed in favor of tinkerbell.
